### PR TITLE
Add designs for International and Non-teacher users

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
   features: {
-    'aso-loop': false
+    'aso-loop': false,
+    'international-and-non-teacher': true
   }
 }

--- a/app/routes/register.js
+++ b/app/routes/register.js
@@ -4,6 +4,16 @@ const {
 } = require('../utils/register-wizard-paths')
 
 module.exports = router => {
+  router.all('/register/*', (req, res, next) => {
+    const registerData = req.session.data.register
+    res.locals.isInternational = registerData && registerData['teach-in-england'] === 'No, I’m a teacher somewhere else'
+    res.locals.isNonTeacher = registerData && registerData['teach-in-england'] === 'No, I’m not a teacher'
+
+    // Allow a non-answer to default to England teacher
+    res.locals.isEnglandTeacher = !(res.locals.isNonTeacher || res.locals.isInternational)
+    next()
+  })
+
   router.get('/register', (req, res) => {
     res.render('register/index', { paths: registerWizardPaths(req) })
   })

--- a/app/routes/register.js
+++ b/app/routes/register.js
@@ -1,16 +1,15 @@
 const {
   registerWizardPaths,
-  registerWizardForks
+  registerWizardForks,
+  typeOfUser
 } = require('../utils/register-wizard-paths')
 
 module.exports = router => {
   router.all('/register/*', (req, res, next) => {
-    const registerData = req.session.data.register
-    res.locals.isInternational = registerData && registerData['teach-in-england'] === 'No, I’m a teacher somewhere else'
-    res.locals.isNonTeacher = registerData && registerData['teach-in-england'] === 'No, I’m not a teacher'
-
-    // Allow a non-answer to default to England teacher
-    res.locals.isEnglandTeacher = !(res.locals.isNonTeacher || res.locals.isInternational)
+    const typesOfUser = typeOfUser(req)
+    res.locals.isInternational = typesOfUser.isInternational
+    res.locals.isNonTeacher = typesOfUser.isNonTeacher
+    res.locals.isEnglandTeacher = typesOfUser.isEnglandTeacher
     next()
   })
 

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -7,7 +7,6 @@ function registerWizardPaths (req) {
   var paths = [
     '/start',
     '/register/chosen',
-    '/register/share-information',
     '/register/trn',
     '/register/name-changes',
     '/register/email',
@@ -24,6 +23,7 @@ function registerWizardPaths (req) {
     '/register/aso-funding',
     '/register/choose-provider',
     '/register/funding-vague',
+    '/register/share-information',
     '/register/check',
     '/register/confirmation',
 
@@ -96,7 +96,7 @@ function registerWizardForks (req) {
       currentPath: '/register/choose-provider',
       storedData: ['register', 'course'],
       values: ['Additional Support Offer for new headteachers'],
-      forkPath: '/register/check'
+      forkPath: '/register/share-information'
     },
     {
       currentPath: '/register/aso-completed-npqh',

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -4,6 +4,8 @@ const {
 } = require('../utils/wizard-helpers')
 
 function registerWizardPaths (req) {
+  const isEnglandTeacher = typeOfUser(req).isEnglandTeacher
+
   var paths = [
     '/start',
     '/register/teach-in-england',
@@ -13,8 +15,10 @@ function registerWizardPaths (req) {
     '/register/email',
     '/register/email-confirmation',
     '/register/personal-details',
-    '/register/where-school',
-    '/register/which-school',
+    ...isEnglandTeacher ? [
+      '/register/where-school',
+      '/register/which-school'
+    ] : [],
     // '/register/funding', // temporarily disable funding pending logic
     '/register/choose-npq',
     '/register/aso',
@@ -135,7 +139,18 @@ function registerWizardForks (req) {
   return nextForkPath(forks, req)
 }
 
+function typeOfUser (req) {
+  const registerData = req.session.data.register
+  const isInternational = registerData && registerData['teach-in-england'] === 'No, I’m a teacher somewhere else'
+  const isNonTeacher = registerData && registerData['teach-in-england'] === 'No, I’m not a teacher'
+
+  // Allow a non-answer to default to England teacher
+  const isEnglandTeacher = !(isNonTeacher || isInternational)
+  return { isInternational, isNonTeacher, isEnglandTeacher }
+}
+
 module.exports = {
   registerWizardPaths,
-  registerWizardForks
+  registerWizardForks,
+  typeOfUser
 }

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -27,7 +27,7 @@ function registerWizardPaths (req) {
     '/register/aso-early-headship',
     '/register/aso-funding',
     '/register/choose-provider',
-    '/register/funding-vague',
+    ...isEnglandTeacher ? ['/register/funding-vague'] : ['/register/funding'],
     '/register/share-information',
     '/register/check',
     '/register/confirmation',

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -6,6 +6,7 @@ const {
 function registerWizardPaths (req) {
   var paths = [
     '/start',
+    '/register/teach-in-england',
     '/register/chosen',
     '/register/trn',
     '/register/name-changes',

--- a/app/views/register/check.html
+++ b/app/views/register/check.html
@@ -1,13 +1,11 @@
 {% extends "_wizard-page.html" %}
-{% set title = 'Check your details
-' %}
+{% set title = 'Check your answers before confirming your registration' %}
 {% set isASO = (data.register.course == 'Additional Support Offer (ASO) for NPQH') %}
 {% set buttonText = 'Confirm' %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
 {% block page %}
 <h1 class="govuk-heading-xl" >{{ title }}</h1>
-<p>Ensure the following information is correct before continuing.</p>
 {{ govukSummaryList({
   rows: [
     {

--- a/app/views/register/check.html
+++ b/app/views/register/check.html
@@ -111,7 +111,7 @@
           }
         ]
       }
-    },
+    } if isEnglandTeacher,
     {
       key: {
         text: "Course"

--- a/app/views/register/check.html
+++ b/app/views/register/check.html
@@ -12,6 +12,23 @@
   rows: [
     {
       key: {
+        text: "Are you a teacher in England, Jersey, Guernsey or the Isle of Man?"
+      },
+      value: {
+        text: data.register['teach-in-england'] | capitaliseFirstLetter
+      },
+      actions: {
+        items: [
+          {
+            href: "/register/teach-in-england",
+            text: "Change",
+            visuallyHiddenText: "if you are a teacher in England"
+          }
+        ]
+      }
+    },
+    {
+      key: {
         text: "Full name"
       },
       value: {
@@ -213,7 +230,24 @@
           }
         ]
       }
-    }
+    },
+    {
+      key: {
+        text: "Funding"
+      },
+      value: {
+        text: data.register.funding
+      },
+      actions: {
+        items: [
+          {
+            href: "/register/funding",
+            text: "Change",
+            visuallyHiddenText: " funding"
+          }
+        ]
+      }
+    } if not isEnglandTeacher
   ]
 }) }}
 {% endblock %}

--- a/app/views/register/choose-npq.html
+++ b/app/views/register/choose-npq.html
@@ -35,7 +35,7 @@
         hint: {
           text: "The Additional Support Offer is a targeted support package for new headteachers. "
         }
-      }
+      } if isEnglandTeacher
     ]
   } | decorateFormAttributes(['register', 'course']) ) }}
 {% endblock %}

--- a/app/views/register/choose-provider.html
+++ b/app/views/register/choose-provider.html
@@ -6,7 +6,9 @@
 
   <p>These are the training providers who provide {{ data.register.course }}. Providers may have different entry requirements.</p>
 
-  <p>Check with the person responsible for professional development at your school or college.</p>
+  {% if isEnglandTeacher %}
+    <p>Check with the person responsible for professional development at your school or college.</p>
+  {% endif %}
 
   {{ govukRadios({
     items: [

--- a/app/views/register/confirmation.html
+++ b/app/views/register/confirmation.html
@@ -20,7 +20,7 @@
 
     <p>They will provide details of timings, costs and deadlines.</p>
 
-    {% if isNPQH %}
+    {% if isNPQH and isEnglandTeacher %}
       <h2 class="govuk-heading-m">Additional Support Offer for new headteachers</h2>
 
       <p>The Additional Support Offer is a targeted support package for new headteachers.</p>

--- a/app/views/register/funding.html
+++ b/app/views/register/funding.html
@@ -19,10 +19,10 @@
     items: [
       {
         text: "My school or college is covering the cost"
-      },
+      } if isEnglandTeacher,
       {
         text: "My trust is paying"
-      },
+      } if isEnglandTeacher,
       {
         text: "I am paying"
       },

--- a/app/views/register/funding.html
+++ b/app/views/register/funding.html
@@ -1,16 +1,19 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Funding' %}
+{% set legend = 'How is your ' + (data.register.npq or 'course') + ' being paid for?' %}
+{% set title = 'Funding' if isEnglandTeacher else legend %}
 
 {% block form %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
-
-  <p>Your school or college is not eligible for NPQ government scholarship funding.</p>
+  {% if isEnglandTeacher %}
+    <h1 class="govuk-heading-xl">{{ title }}</h1>
+    <p>Your school or college is not eligible for NPQ government scholarship funding.</p>
+  {% endif %}
 
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: 'How is your ' + (data.register.npq or 'course') + ' being paid for?',
-        classes: "govuk-fieldset__legend--s"
+        text: legend,
+        isPageTitle: not isEnglandTeacher,
+        classes: "govuk-fieldset__legend--s" if isEnglandTeacher else "govuk-fieldset__legend--xl govuk-!-margin-bottom-6"
       }
     },
     items: [
@@ -30,5 +33,5 @@
         }
       }
     ]
-  } | decorateFormAttributes(['register', 'provider']) ) }}
+  } | decorateFormAttributes(['register', 'funding']) ) }}
 {% endblock %}

--- a/app/views/register/name-changes.html
+++ b/app/views/register/name-changes.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Has your name changed since you first registered as a teacher?' if isEnglandTeacher else 'Has your name changed since you registered with the Teacher Regulation Agency?' %}
+{% set title = 'Has your name changed since you first registered as a teacher?' if isEnglandTeacher else 'Has your name changed since you received your teacher reference number (TRN)?' %}
 
 {% block form %}
   <h1 class="govuk-heading-l">{{ title }}</h1>

--- a/app/views/register/name-changes.html
+++ b/app/views/register/name-changes.html
@@ -1,20 +1,12 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Name changes' %}
+{% set title = 'Has your name changed since you first registered as a teacher?' if isEnglandTeacher else 'Has your name changed since you registered with the Teacher Regulation Agency?' %}
 
 {% block form %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <h1 class="govuk-heading-l">{{ title }}</h1>
 
   <p>Your name must match the name held in the Teaching Regulation Agency records to confirm you can take an NPQ.</p>
 
-  <p>If it does not match, you cannot continue with an NPQ.</p>
-
   {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: 'Has your name changed since you first registered as a teacher?',
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
     items: [
       {
         text: "Yes, I have changed my name",

--- a/app/views/register/personal-details.html
+++ b/app/views/register/personal-details.html
@@ -61,14 +61,42 @@
       }
     }) }}
 
-    {{ govukInput({
-      label: {
-        text: "National Insurance number (optional)",
-        classes: "govuk-label--s"
-      },
-      classes: 'govuk-!-width-three-quarters',
-      hint: {
-        text: 'This will help us match your details. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-      }
-    } | decorateFormAttributes(['register', 'nino']) ) }}
+    {% set nino %}
+      {{ govukInput({
+        label: {
+          text: "National Insurance number",
+          classes: "govuk-label--s"
+        },
+        classes: 'govuk-!-width-three-quarters',
+        hint: {
+          text: 'This will help us match your details. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      } | decorateFormAttributes(['register', 'nino']) ) }}
+    {% endset %}
+
+    {% if isEnglandTeacher %}
+      {{ nino | safe }}
+    {% else %}
+      {{ govukRadios({
+        fieldset: {
+          legend: {
+            text: 'Do you have a National Insurance number?',
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          {
+            text: "Yes, I have a National Insurance number",
+            value: "yes",
+            conditional: {
+              html: nino
+            }
+          },
+          {
+            text: "No, I do not",
+            value: "no"
+          }
+        ]
+      } | decorateFormAttributes(['register', 'have-nino']) ) }}
+    {% endif %}
 {% endblock %}

--- a/app/views/register/teach-in-england.html
+++ b/app/views/register/teach-in-england.html
@@ -16,11 +16,11 @@
         value: "yes"
       },
       {
-        text: "No, I teach somewhere else"
+        text: "No, I’m a teacher somewhere else"
       },
       {
-        text: "No, I am not a teacher"
+        text: "No, I’m not a teacher"
       }
     ]
-  } | decorateFormAttributes(['register', 'teach-england']) ) }}
+  } | decorateFormAttributes(['register', 'teach-in-england']) ) }}
 {% endblock %}

--- a/app/views/register/teach-in-england.html
+++ b/app/views/register/teach-in-england.html
@@ -1,0 +1,26 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'Are you a teacher in England, Jersey, Guernsey or the Isle of Man?' %}
+
+{% block form %}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: title,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--xl"
+      }
+    },
+    items: [
+      {
+        text: "Yes",
+        value: "yes"
+      },
+      {
+        text: "No, I teach somewhere else"
+      },
+      {
+        text: "No, I am not a teacher"
+      }
+    ]
+  } | decorateFormAttributes(['register', 'teach-england']) ) }}
+{% endblock %}

--- a/app/views/register/trn.html
+++ b/app/views/register/trn.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'You need your teacher reference number to register for an NPQ' if isEnglandTeacher else 'You need a teacher reference number to register for an NPQ' %}
+{% set title = 'You need your teacher reference number to register for an NPQ' if isEnglandTeacher else 'You’ll need a teacher reference number to register for an NPQ' %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>

--- a/app/views/register/trn.html
+++ b/app/views/register/trn.html
@@ -1,37 +1,73 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Teacher reference number' %}
+{% set title = 'You need your teacher reference number to register for an NPQ' if isEnglandTeacher else 'You need a teacher reference number to register for an NPQ' %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  <p>Your teacher reference number (TRN) is used to check you’re eligible to study for a national professional qualification (NPQ).</p>
+  {% if isEnglandTeacher %}
+    <p>Your teacher reference number (TRN) is used to check you’re eligible to study for a national professional qualification (NPQ).</p>
 
-  <p>If you don’t know what your TRN is, this can usually be found on your payslip, teachers’ pension documentation or teacher training records.</p>
+    <p>If you don’t know what your TRN is, this can usually be found on your payslip, teachers’ pension documentation or teacher training records.</p>
 
-  <p>The TRN has previously been known as a QTS, GTC, DfE, DfES or DCSF number.</p>
+    <p>The TRN has previously been known as a QTS, GTC, DfE, DfES or DCSF number.</p>
 
-  <p>You may not have a TRN if you are working in further education or qualified outside England or overseas.</p>
+    <p>You may not have a TRN if you are working in further education or qualified outside England or overseas.</p>
 
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: 'Do you know your teacher reference number (TRN)?',
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
-    items: [
-      {
-        text: "Yes, I know my TRN",
-        value: "yes"
+    {{ govukRadios({
+      fieldset: {
+        legend: {
+          text: 'Do you know your teacher reference number (TRN)?',
+          classes: "govuk-fieldset__legend--m"
+        }
       },
-      {
-        text: "No, I do not know my TRN",
-        value: "dont-know"
+      items: [
+        {
+          text: "Yes, I know my TRN",
+          value: "yes"
+        },
+        {
+          text: "No, I do not know my TRN",
+          value: "dont-know"
+        },
+        {
+          text: "I do not have a TRN",
+          value: "no-trn"
+        }
+      ]
+    } | decorateFormAttributes(['register', 'know-trn']) ) }}
+  {% else %}
+    <p>You may not have a teacher reference number (TRN) if you:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>qualified outside England or overseas</li>
+      <li>are not a qualified teacher</li>
+      <li>are working in further education</li>
+    </ul>
+
+    <p>The TRN has previously been known as a QTS, GTC, DfE, DfES or DCSF number.</p>
+
+    <p>If you think you have a TRN, it can usually be found on a teacher’s payslip, pension documentation or teacher training records.</p>
+
+    {{ govukRadios({
+      fieldset: {
+        legend: {
+          text: 'Do you have a teacher reference number (TRN)?',
+          classes: "govuk-fieldset__legend--m"
+        }
       },
-      {
-        text: "I do not have a TRN",
-        value: "no-trn"
-      }
-    ]
-  } | decorateFormAttributes(['register', 'know-trn']) ) }}
+      items: [
+        {
+          text: "Yes, I know my TRN",
+          value: "yes"
+        },
+        {
+          text: "Yes, but I need to be reminded what it is",
+          value: "dont-know"
+        },
+        {
+          text: "No, I need to get a TRN",
+          value: "no-trn"
+        }
+      ]
+    } | decorateFormAttributes(['register', 'know-trn']) ) }}
+  {% endif %}
 {% endblock %}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -20,7 +20,9 @@
 
       <p>You must:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>only use this service if you are a teacher working in England, Guernsey, Jersey or the Isle of Man – if you are a teacher working outside these locations contact your provider directly to register</li>
+        {% if not data.features['international-and-non-teacher'] %}
+          <li>only use this service if you are a teacher working in England, Guernsey, Jersey or the Isle of Man – if you are a teacher working outside these locations contact your provider directly to register</li>
+        {% endif %}
         <li>have your teacher reference number (TRN)</li>
         <li>have your funding source confirmed – either a scholarship, school, college or personal funding</li>
         <li>know which NPQ course you want to study</li>
@@ -29,7 +31,7 @@
 
       {{ govukButton({
         text: 'Start now',
-        href: '/register/chosen',
+        href: '/register/teach-in-england' if data.features['international-and-non-teacher'] else '/register/chosen',
         isStartButton: true,
         classes: 'govuk-!-margin-top-4'
       }) }}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -10,7 +10,7 @@
         {{ title }}
       </h1>
 
-      <p>This service is for teachers who want to register:</p>
+      <p>Use this service to register:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>to study for an NPQ</li>
         <li>for the Additional Support Offer for new headteachers</li>

--- a/lib/core_filters.js
+++ b/lib/core_filters.js
@@ -29,8 +29,9 @@ module.exports = function (env) {
   }
 
   // example: "not like this" becomes "Not like this"
+  // do not error when string is undefined
   filters.capitaliseFirstLetter = string => {
-    return string.charAt(0).toUpperCase() + string.slice(1)
+    return string ? string.charAt(0).toUpperCase() + string.slice(1) : string
   }
 
   return filters


### PR DESCRIPTION
- Ask an initial question about whether the user is a teacher in England
- No, teacher elsewhere = International user
- No, not a teacher = Non teacher user
- Use this logic to determine what content/fields to show – the actual journey doesn’t vary too much, there's different guidance and some labels have been tweaked
- The choose school steps are removed for these users

![02-are-you-a-teacher-in-england](https://user-images.githubusercontent.com/319055/135074208-8a8f6332-3f15-44f1-89c3-bbe984028b8b.png)
