### PR TITLE
Split ‘Check your details‘ into page-per-thing and remove name change flow

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
   features: {
     'aso-loop': false,
-    'international-and-non-teacher': true
+    'international-and-non-teacher': true,
+    'name-changes': true
   }
 }

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -11,10 +11,10 @@ function registerWizardPaths (req) {
     '/register/teach-in-england',
     '/register/chosen',
     '/register/trn',
-    '/register/name-changes',
     '/register/email',
     '/register/email-confirmation',
     '/register/personal-details',
+    // '/register/name-changes', Disable ‘Have you changed your name’ flow
     ...isEnglandTeacher ? [
       '/register/where-school',
       '/register/which-school'
@@ -32,10 +32,10 @@ function registerWizardPaths (req) {
     '/register/check',
     '/register/confirmation',
 
-    '/register/name-changes',
-    '/register/updated-name',
-    '/register/updating-your-name',
-    '/register/change-name-on-tra',
+    // '/register/name-changes',
+    // '/register/updated-name',
+    // '/register/updating-your-name',
+    // '/register/change-name-on-tra',
 
     '/register/aso',
     '/register/aso-funding-not-available',

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -13,13 +13,16 @@ function registerWizardPaths (req) {
     '/register/trn',
     '/register/email',
     '/register/email-confirmation',
-    '/register/personal-details',
+    '/register/your-trn',
+    '/register/your-name',
+    '/register/your-dob',
+    '/register/your-nino',
     // '/register/name-changes', Disable ‘Have you changed your name’ flow
+    // '/register/personal-details',
     ...isEnglandTeacher ? [
       '/register/where-school',
       '/register/which-school'
     ] : [],
-    // '/register/funding', // temporarily disable funding pending logic
     '/register/choose-npq',
     '/register/aso',
     '/register/aso-completed-npqh',

--- a/app/utils/register-wizard-paths.js
+++ b/app/utils/register-wizard-paths.js
@@ -5,20 +5,22 @@ const {
 
 function registerWizardPaths (req) {
   const isEnglandTeacher = typeOfUser(req).isEnglandTeacher
+  const data = req.session.data
 
   var paths = [
     '/start',
     '/register/teach-in-england',
     '/register/chosen',
     '/register/trn',
+    ...data.features['name-changes'] ? ['/register/name-changes'] : [],
     '/register/email',
     '/register/email-confirmation',
-    '/register/your-trn',
-    '/register/your-name',
-    '/register/your-dob',
-    '/register/your-nino',
-    // '/register/name-changes', Disable ‘Have you changed your name’ flow
-    // '/register/personal-details',
+    ...data.features['name-changes'] ? ['/register/personal-details'] : [
+      '/register/your-trn',
+      '/register/your-name',
+      '/register/your-dob',
+      '/register/your-nino'
+    ],
     ...isEnglandTeacher ? [
       '/register/where-school',
       '/register/which-school'
@@ -35,10 +37,11 @@ function registerWizardPaths (req) {
     '/register/check',
     '/register/confirmation',
 
-    // '/register/name-changes',
-    // '/register/updated-name',
-    // '/register/updating-your-name',
-    // '/register/change-name-on-tra',
+    ...data.features['name-changes'] ? [
+      '/register/name-changes',
+      '/register/updated-name',
+      '/register/updating-your-name',
+      '/register/change-name-on-tra'] : [],
 
     '/register/aso',
     '/register/aso-funding-not-available',

--- a/app/views/register/check.html
+++ b/app/views/register/check.html
@@ -35,7 +35,7 @@
       actions: {
         items: [
           {
-            href: "/register/personal-details",
+            href: "/register/your-name",
             text: "Change",
             visuallyHiddenText: "name"
           }
@@ -52,7 +52,7 @@
       actions: {
         items: [
           {
-            href: "/register/personal-details",
+            href: "/register/your-trn",
             text: "Change",
             visuallyHiddenText: "TRN"
           }
@@ -69,9 +69,9 @@
       actions: {
         items: [
           {
-            href: "/register/personal-details",
+            href: "/register/your-dob",
             text: "Change",
-            visuallyHiddenText: "TRN"
+            visuallyHiddenText: "date of birth"
           }
         ]
       }
@@ -86,7 +86,7 @@
       actions: {
         items: [
           {
-            href: "/register/personal-details",
+            href: "/register/your-nino",
             text: "Change",
             visuallyHiddenText: "national insurance number"
           }

--- a/app/views/register/check.html
+++ b/app/views/register/check.html
@@ -35,7 +35,7 @@
       actions: {
         items: [
           {
-            href: "/register/your-name",
+            href: "/register/personal-details" if data.features['name-changes'] else "/register/your-name",
             text: "Change",
             visuallyHiddenText: "name"
           }
@@ -52,7 +52,7 @@
       actions: {
         items: [
           {
-            href: "/register/your-trn",
+            href: "/register/personal-details" if data.features['name-changes'] else "/register/your-trn",
             text: "Change",
             visuallyHiddenText: "TRN"
           }
@@ -69,7 +69,7 @@
       actions: {
         items: [
           {
-            href: "/register/your-dob",
+            href: "/register/personal-details" if data.features['name-changes'] else "/register/your-dob",
             text: "Change",
             visuallyHiddenText: "date of birth"
           }
@@ -86,7 +86,7 @@
       actions: {
         items: [
           {
-            href: "/register/your-nino",
+            href: "/register/personal-details" if data.features['name-changes'] else "/register/your-nino",
             text: "Change",
             visuallyHiddenText: "national insurance number"
           }

--- a/app/views/register/email.html
+++ b/app/views/register/email.html
@@ -1,15 +1,15 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Email details' %}
+{% set title = 'Email address' %}
 
 {% block form %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
-
-  <p>We’ll email you a code to confirm your email address.</p>
-
   {{ govukInput({
     label: {
-      text: "Email address",
-      classes: "govuk-label--s"
+      text: title,
+      isPageTitle: true,
+      classes: "govuk-label--xl"
+    },
+    hint: {
+      html: '<p>We’ll email you a code to confirm your email address.</p>'
     }
   } | decorateFormAttributes(['register', 'email']) ) }}
 {% endblock %}

--- a/app/views/register/trn.html
+++ b/app/views/register/trn.html
@@ -26,7 +26,7 @@
           value: "yes"
         },
         {
-          text: "No, I do not know my TRN",
+          text: "No, I need a reminder",
           value: "dont-know"
         },
         {

--- a/app/views/register/validation-failed.html
+++ b/app/views/register/validation-failed.html
@@ -1,0 +1,37 @@
+{% extends "_wizard-page.html" %}
+{% set title = 'We cannot find your details' %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">{{ title }}</h1>
+    <p>We cannot find a match with the details you have provided.</p>
+
+    <p>This could be because:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you have abbreviated your first name, for example Rob/Robert</li>
+      <li>your surname is different to the name held on the Teaching Regulation Agency records</li>
+      <li>you’ve entered an incorrect TRN</li>
+      <li>you have entered an incorrect date of birth</li>
+    </ul>
+
+    <p>Try again to enter your details - entering your National Insurance number will help us match your details.</p>
+
+    {{ govukButton({
+      text: 'Try again',
+      href: '#'
+    }) }}
+
+    <h2 class="govuk-heading-m">Still can’t match your details?</h2>
+
+    <p>You can still continue to register - our support team will manually match your details over the next few weeks. You will only be contacted if we cannot match your details.</p>
+
+    {{ govukButton({
+      text: 'Continue registration',
+      href: '#',
+      classes: 'govuk-button--secondary'
+    }) }}
+  </div>
+</div>
+{% endblock %}

--- a/app/views/register/your-dob.html
+++ b/app/views/register/your-dob.html
@@ -1,0 +1,38 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'What’s your date of birth?' %}
+
+{% block form %}
+  {{ govukDateInput({
+    id: 'dob',
+    fieldset: {
+      legend: {
+        text: title,
+        isPageTitle: true,
+        classes: "govuk-fieldset__legend--xl"
+      }
+    },
+    items: [
+      {
+        name: '[register][dob-day]',
+        value: data['register']['dob-day'],
+        classes: "govuk-input--width-2",
+        label: 'Day'
+      },
+      {
+        name: '[register][dob-month]',
+        value: data['register']['dob-month'],
+        classes: "govuk-input--width-2",
+        label: 'Month'
+      },
+      {
+        name: '[register][dob-year]',
+        value: data['register']['dob-year'],
+        classes: "govuk-input--width-4",
+        label: 'Year'
+      }
+    ],
+    hint: {
+      text: "For example, 12 11 1990"
+    }
+  }) }}
+{% endblock %}

--- a/app/views/register/your-name.html
+++ b/app/views/register/your-name.html
@@ -1,0 +1,33 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'What’s your name?' %}
+
+{% block form %}
+  {% set nameHelp %}
+    <p>If your name has changed and you have not updated your Teaching Regulation Agency record, you can:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>use your previous name to register with the service</li>
+      <li>use your previous name to register, and then change it on the Teaching Regulation Agency records at a later date</li>
+      <li><a href="/register/change-name-on-tra">change your name on the Teaching Regulation Agency records</a> first and then return to register for an NPQ</li>
+    </ul>
+
+    <p>It will take a minimum of 5 days to update your Teaching Regulation Agency records.</p>
+
+    <p>If you are unsure whether you have updated your name, you can <a href="#">request a reminder</a>.</p>
+  {% endset %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+
+  <p>Give your full name, exactly as it appears on the Teaching Regulation Agency&nbsp;records.</p>
+
+  {{ govukDetails({
+    summaryText: "Help if you have changed your name",
+    html: nameHelp
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: 'Full name',
+      classes: "govuk-label--m"
+    }
+  } | decorateFormAttributes(['register', 'name']) ) }}
+{% endblock %}

--- a/app/views/register/your-nino.html
+++ b/app/views/register/your-nino.html
@@ -1,0 +1,16 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'What’s your national insurance number?' %}
+
+{% block form %}
+  {{ govukInput({
+    label: {
+      text: title,
+      isPageTitle: true,
+      classes: "govuk-label--xl"
+    },
+    hint: {
+      html: '<p>It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’</p>'
+    },
+    classes: 'govuk-!-width-one-third'
+  } | decorateFormAttributes(['register', 'nino']) ) }}
+{% endblock %}

--- a/app/views/register/your-nino.html
+++ b/app/views/register/your-nino.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'What’s your national insurance number?' %}
+{% set title = 'What’s your National Insurance number?' %}
 
 {% block form %}
   {{ govukInput({

--- a/app/views/register/your-trn.html
+++ b/app/views/register/your-trn.html
@@ -5,8 +5,8 @@
   <h1 class="govuk-heading-xl">{{ title }}</h1>
   <p>This unique ID is:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>usually 7 digits long, for example ’4567814’</li>
-    <li>may include the letters ’RP’ or a slash ’/’ symbol, for example ’RP99/12345’</li>
+    <li>usually 7 digits long, for example ‘4567814’</li>
+    <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
     <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
   </ul>
 

--- a/app/views/register/your-trn.html
+++ b/app/views/register/your-trn.html
@@ -1,0 +1,22 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'What’s your teacher reference number (TRN)?' %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+  <p>This unique ID is:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>usually 7 digits long, for example ’4567814’</li>
+    <li>may include the letters ’RP’ or a slash ’/’ symbol, for example ’RP99/12345’</li>
+    <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
+  </ul>
+
+  <p>You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
+
+  {{ govukInput({
+    label: {
+      text: "Teacher reference number (TRN)",
+      classes: "govuk-label--s"
+    },
+    classes: 'govuk-!-width-one-third'
+  } | decorateFormAttributes(['register', 'trn']) ) }}
+{% endblock %}


### PR DESCRIPTION
- Remove the name change flow, instead moving guidance onto the ‘What’s your name?’ page
- Split the rest of the details page into a page-per-thing, for TRN, NINO and DOB
- Update Check your answers to link to these individual pages 