### PR TITLE
Add extra funding options for international and non-teacher

### DIFF
--- a/app/views/register/funding.html
+++ b/app/views/register/funding.html
@@ -18,11 +18,14 @@
     },
     items: [
       {
-        text: "My school or college is covering the cost"
-      } if isEnglandTeacher,
+        text: "My school or college is paying"
+      },
       {
         text: "My trust is paying"
       } if isEnglandTeacher,
+      {
+        text: "My employer is paying"
+      } if not isEnglandTeacher,
       {
         text: "I am paying"
       },


### PR DESCRIPTION
We've found from a survey that providers often expect an employer or school to pay for these users.

![08-how-is-course-being-paid-for](https://user-images.githubusercontent.com/319055/136391633-dd94e8ed-7ec0-4cd1-899e-e5a63de70db2.png)

