### PR TITLE
Update 'Get an identity' content for the NPQ context

### DIFF
--- a/app/views/register/ask-questions.html
+++ b/app/views/register/ask-questions.html
@@ -15,6 +15,6 @@
   {% if data.features.trnRequired.on %}<li>teacher reference number (TRN)</li>{% endif %}
 </ul>
 
-<p class="govuk-!-margin-bottom-6">We may ask some follow-up questions.</p>
+<p class="govuk-!-margin-bottom-6">We may also ask some follow-up questions.</p>
 
 {% endblock %}

--- a/app/views/register/ask-questions.html
+++ b/app/views/register/ask-questions.html
@@ -1,8 +1,10 @@
 {% extends "_wizard-form.html" %}
-{% set title = "We’ll ask you some questions to check against our records" %}
+{% set title = "Your details" %}
 
 {% block form %}
-<h1 class="govuk-panel__title">We’ll ask you some questions to check against our records</h1>
+<h1 class="govuk-panel__title">Your details</h1>
+
+<p>Before you register for an NPQ, we’ll ask you for a few details to find you in our records.</p>
 
 <p>We’ll ask for your:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -13,11 +15,6 @@
   {% if data.features.trnRequired.on %}<li>teacher reference number (TRN)</li>{% endif %}
 </ul>
 
-<p class="govuk-!-margin-bottom-6">
- 
-    If you do not have your TRN or National Insurance number available, we may ask some follow-up questions.
-
- 
-</p>
+<p class="govuk-!-margin-bottom-6">We may ask some follow-up questions.</p>
 
 {% endblock %}

--- a/app/views/register/email.html
+++ b/app/views/register/email.html
@@ -1,15 +1,15 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'What’s your email address?' %}
+{% set title = 'Your email address' %}
 
 {% block form %}
+<h1 class='govuk-heading-xl'>Your email address</h1>
+<p>We use your email address to find your details in our records.</p>
+<p>If we do not recognise your email, we’ll ask you for a few details instead.</p>
+<p class="govuk-body govuk-!-margin-bottom-6">You’ll receive a code by email to confirm your email address.</p>
   {{ govukInput({
     label: {
-      text: title,
-      isPageTitle: true,
-      classes: "govuk-label--xl"
-    },
-    hint: {
-      html: '<p>We’ll send you a code to confirm your email address.</p>'
+      text: "What’s your email address?",
+      classes: "govuk-label--m"
     },
     value: ''
   } | decorateFormAttributes(['register', 'email']) ) }}

--- a/app/views/register/finish-gai.html
+++ b/app/views/register/finish-gai.html
@@ -2,12 +2,10 @@
 {% set title = "Continue with your NPQ registration" %}
 
 {% block form %}
-<h1 class="govuk-panel__title">You can continue</h1>
+<h1 class="govuk-panel__title">Continue to register for an NPQ</h1>
 
 <p>Thank you, we’ve finished checking our records.</p>
- 
 
-  <h2 class="govuk-heading-m">Next time</h2>
-  <p class="govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>{{ data['email-address'] or "email@example.com" }}</b></p>
+<p class="govuk-!-margin-bottom-6">We’ll only need your email address (<b>{{ data['email-address'] or "email@example.com" }}</b>) to find your details in the future.</p>
 
 {% endblock %}


### PR DESCRIPTION
- Make the 'Get an identity' content suitable for the NPQ service. For example, remove references to 'signing in' as the NPQ service does not sign you in.
- Explain why we collect email address

| Before  | After |
| ------------- |:-------------:|
| ![Screenshot 2022-10-17 at 18 02 30](https://user-images.githubusercontent.com/56349171/196238962-67784a21-0979-4d2a-8fe6-148095aa65f8.png)      | ![Screenshot 2022-10-17 at 18 03 19](https://user-images.githubusercontent.com/56349171/196239105-8dd13ec5-ac1b-481d-9395-00b94aa78147.png)     |
| ![Screenshot 2022-10-17 at 18 04 35](https://user-images.githubusercontent.com/56349171/196239384-bf8be5a6-b930-480e-82f1-6792cc5c7933.png)      | ![Screenshot 2022-10-17 at 18 06 18](https://user-images.githubusercontent.com/56349171/196239672-5c11ca75-ed21-49a8-b433-0d839d5ae381.png)     |
| ![Screenshot 2022-10-17 at 18 07 14](https://user-images.githubusercontent.com/56349171/196239852-e5d24018-c4b2-43c8-a2a8-74aea80ba22b.png)      | ![Screenshot 2022-10-17 at 18 07 46](https://user-images.githubusercontent.com/56349171/196239943-c60a94b0-554f-44e0-a175-85ea3c81e1f4.png)     |








