### PR TITLE
Temporary content adds hint text next to school led network to discourage users registering with them

### DIFF
--- a/app/views/choose-provider.html
+++ b/app/views/choose-provider.html
@@ -137,7 +137,10 @@
           },
           {
             value: "School-Led Network",
-            text: "School-Led Network"
+            text: "School-Led Network",
+            hint: {
+            text: "You can only register with this provider if you already started your NPQ with them in October 2022."
+            }
           },
           {
             value: "Teacher Development Trust",


### PR DESCRIPTION
You should only register with school led network if you're part of their October 2022 cohort. as school led network will no longer be a lead provider. 

We don't want to remove school-led network from this list just yet, as there may be a few stragglers from the October 2022 who have not registered yet. 

Add hint text to this effect.

![Screenshot 2022-11-28 at 12 15 28](https://user-images.githubusercontent.com/56349171/204275512-92039061-d205-41af-893c-5fc390cc927a.png)
