### PR TITLE
make npq page more readable

### DIFF
--- a/app/views/choose-npq.html
+++ b/app/views/choose-npq.html
@@ -15,24 +15,11 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Which NPQ do you want to do?</h1>
+    <h1 class="govuk-heading-xl">Choose an NPQ</h1>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Help with NPQH and the Early Headship Coaching Offer
-        </span>
-      </summary>
+      <p class="govuk-body govuk-!-margin-bottom-6">To register for both the headship NPQ and the <a href="https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer">early headship coaching offer</a>, you need to submit 2 seperate registrations.</p>
 
-      <div class="govuk-details__text">
-        <p>If you’re applying to start an NPQ for Headship (NPQH), you might also be applying for the Early Headship Coaching Offer, a package of structured face-to-face support for new headteachers.</p>
-        <p>To register for both you should:</p>
-        <ul class = "govuk-list govuk-list--bullet">
-          <li>complete your registration for an NPQH using this service</li>
-          <li>complete a separate registration for the Early Headship Coaching Offer, also using this service</li>
-        </ul>
-      </div>
-    </details>
+      <h1 class="govuk-heading-m">Which NPQ do you want to do?</h1>
 
     <form class="form" action="/check-data/_funding-check" method="post">
       {{ govukRadios({
@@ -40,44 +27,44 @@
         items: [
           {
             value: "NPQ for Leading Behaviour and Culture (NPQLBC)",
-            text: "NPQ for Leading Behaviour and Culture (NPQLBC)"
+            text: "Leading behaviour and culture"
           },
           {
             value: "NPQ for Leading Literacy (NPQLL)",
-            text: "NPQ for Leading Literacy (NPQLL)"
+            text: "Leading literacy"
           },
           {
             value: "NPQ for Leading Teaching (NPQLT)",
-            text: "NPQ for Leading Teaching (NPQLT)"
+            text: "Leading teaching"
           },
           {
             value: "NPQ for Leading Teacher Development (NPQLTD)",
-            text: "NPQ for Leading Teacher Development (NPQLTD)"
+            text: "Leading teacher development"
           },
           {
             value: "NPQ for Senior Leadership (NPQSL)",
-            text: "NPQ for Senior Leadership (NPQSL)"
+            text: "Senior leadership"
           },
           {
             value: "NPQ for Headship (NPQH)",
-            text: "NPQ for Headship (NPQH)"
+            text: "Headship"
           },
           {
             value: "NPQ for Executive Leadership (NPQEL)",
-            text: "NPQ for Executive Leadership (NPQEL)"
+            text: "Executive leadership"
           },
           {
             value: "NPQ for Early Years Leadership (NPQEYL)",
-            text: "NPQ for Early Years Leadership (NPQEYL)"
+            text: "Early years leadership"
           },
           {
             divider: "or"
           },
           {
             value: "The Early Headship Coaching Offer",
-            text: "The Early Headship Coaching Offer",
+            text: "Early headship coaching offer",
             hint: {
-              text: "The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers."
+              text: "A package of structured face-to-face support for new headteachers."
             }
           }
         ]


### PR DESCRIPTION
## What

Update the 'What are you applying for?' page? with the proposed new content.

## Why

- the word 'apply' in the heading could misleading - users are not 'applying' on the NPQ reg service
- separate the EHCO out from the NPQs to distinguish it as a separate thing
- there's no need to keep repeating 'NPQ' on each radio button - it makes the NPQs harder to spot in the list 
- there's no need to include the NPQ acronyms - they're long, hard remember and not useful especially in this context
- the guidance about applying for the EHCO and the NPQ in headship should not be hidden in a details component - it's hiding essential information from the user and does nothing to promote the EHCO 

| Current content on live  | New proposed content |
| ------------- |:-------------:|
| <img width="587" alt="Screenshot 2022-12-22 at 09 43 35" src="https://user-images.githubusercontent.com/56349171/209105868-edf986ba-ce80-4194-92d4-c21c32101317.png">      | <img width="589" alt="Screenshot 2022-12-21 at 16 56 05" src="https://user-images.githubusercontent.com/56349171/208961231-10e92989-e20f-4cca-b14e-c4301537fcf1.png">     |
