### PR TITLE
Make post submission copy and email copy consistent 

### DIFF
--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -34,9 +34,9 @@
       </p>
 
       {% if (data['choosenpq'] == "NPQ for Headship (NPQH)") %}
-        <h2 class="govuk-heading-m">Early Headship Coaching Offer</h2>
+        <h2 class="govuk-heading-m">Early headship coaching offer</h2>
         <p>You can also  <a href="https://register-national-professional-qualifications.education.gov.uk">register the early headship coaching offer</a>, a one-year support package for new headteachers.</p>
-        <p><a href="https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship">Find out more about the Early Headship Coaching Offer</a>.</p>
+        <p><a href="https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship">Find out more about the early headship coaching offer</a>.</p>
       {% else %}
       {% endif %}
 

--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -24,7 +24,7 @@
       <h2 class="govuk-heading-m">Apply through your provider</h2>
 
       <p class="govuk-body">
-        You still need to apply for your NPQ through {{ data['provider']}}, if you have not done so already.
+        You still need to apply for the {{ data['choosenpq'] }} NPQ through {{ data['provider']}}, if you have not done so already.
       </p>
       <p class="govuk-body">
         They’ll contact you by email to outline the next steps, including how to apply.

--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -13,8 +13,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+
       {% set html %}
-        You’ve registered for the {{ data['choosenpq'] }} NPQ with {{ data['provider'] }}
+      {% if (data['choosenpq'] == "Early headship coaching offer") %}
+      You’ve registered for the Early headship coaching offer with {{ data['provider'] }}
+      {% else %}
+      You’ve registered for the {{ data['choosenpq'] }} NPQ with {{ data['provider'] }}
+      {% endif %}
       {% endset %}
 
       {{ govukPanel({
@@ -23,9 +28,12 @@
 
       <h2 class="govuk-heading-m">Apply through your provider</h2>
 
-      <p class="govuk-body">
-        You still need to apply for the {{ data['choosenpq'] }} NPQ through {{ data['provider']}}, if you have not done so already.
-      </p>
+      {% if (data['choosenpq'] == "Early headship coaching offer") %}
+      <p class="govuk-body">You still need to apply for the Early headship coaching offer through {{ data['provider']}}, if you have not done so already.</p>
+      {% else %}
+      <p class="govuk-body">You still need to apply for the {{ data['choosenpq'] }} NPQ through {{ data['provider']}}, if you have not done so already.</p>
+      {% endif %}
+
       <p class="govuk-body">
         They’ll contact you by email to outline the next steps, including how to apply.
       </p>

--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       {% set html %}
-        You've registered for the {{ data['choosenpq'] }} NPQ with {{ data['provider'] }}
+        You’ve registered for the {{ data['choosenpq'] }} NPQ with {{ data['provider'] }}
       {% endset %}
 
       {{ govukPanel({
@@ -24,10 +24,13 @@
       <h2 class="govuk-heading-m">Apply through your provider</h2>
 
       <p class="govuk-body">
-        You still need to apply for your NPQ through {{ data['provider']}}.
+        You still need to apply for your NPQ through {{ data['provider']}}, if you have not done so already.
       </p>
       <p class="govuk-body">
-        They’ll contact you to outline the next steps, including how to apply.
+        They’ll contact you by email to outline the next steps, including how to apply.
+      </p>
+      <p class="govuk-body">
+      There might be a delay in your provider contacting you while they prepare to open applications for October 2023.
       </p>
 
       {% if (data['choosenpq'] == "NPQ for Headship (NPQH)") %}

--- a/app/views/funding/ehco-already-funded.html
+++ b/app/views/funding/ehco-already-funded.html
@@ -24,7 +24,9 @@
 
       <h2 class="govuk-heading-m">If you’re taking the EHCO again</h2>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">Continue to register. You would need to pay for the EHCO if you were previously funded but you withdrew.</p>
+      <p>Continue to register.</p>
+
+      <p class="govuk-body govuk-!-margin-bottom-7">You would need to pay for the EHCO if you were previously funded but you withdrew.</p>
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/funding/ehco-not-funded.html
+++ b/app/views/funding/ehco-not-funded.html
@@ -22,9 +22,7 @@
 
       <p class="govuk-body">You’re not eligible for scholarship funding for the early headship coaching offer (EHCO).</p>
 
-      <p class="govuk-body"><a href="https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer">Learn about funding eligibility for the EHCO</a>.</p>
-
-      <p class="govuk-body govuk-!-margin-bottom-7">You can still register, but you would need to pay for the EHCO another way.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">This means that you would need to pay for the EHCO another way.</p>
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/funding/funding-not-available.html
+++ b/app/views/funding/funding-not-available.html
@@ -48,11 +48,11 @@
          <!-- Early years + not NPQEYL -->
          {% elseif (data['haveurn'] == "Yes") and (data['choosenpq'] != "NPQ for Early Years Leadership (NPQEYL)") %}
 
-        <p>You’re not eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ because you do not work in one of the eligible settings, such as state funded schools.</p>
+        <p>You’re not eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ because you do not work in one of the eligible settings, such as state-funded schools.</p>
 
         <p>This means that you would need to pay for the course another way.</p>
 
-        <p>However, you are eligible for scholarship funding for the early years leadership NPQ.</p>
+        <p>However, you are eligible for scholarship funding for the Early years leadership NPQ.</p>
 
         <p class="govuk-body govuk-!-margin-bottom-7">You can <a href="/choose-npq.html">go back and select the early years leadership NPQ</a> instead.</p>
 


### PR DESCRIPTION
Make post submission copy consistent with post submission email

| Before  | After |
| ------------- |:-------------:|
| ![Screenshot 2023-03-15 at 14 35 51](https://user-images.githubusercontent.com/56349171/225342774-0ba771a6-580b-4bcb-a8f3-ef9a446cc6b3.png)      |   ![Screenshot 2023-03-15 at 15 26 28](https://user-images.githubusercontent.com/56349171/225358514-d1e908ff-696e-4419-82b2-30c5a12b1210.png)   |



| Before  | After |
| ------------- |:-------------:|
| ![Screenshot 2023-03-15 at 16 30 05](https://user-images.githubusercontent.com/56349171/225376628-433d07d6-ba01-4590-b5d5-599254333c17.png)      |   ![Screenshot 2023-03-15 at 16 26 45](https://user-images.githubusercontent.com/56349171/225375731-7d572edd-c1b6-41d6-a9aa-b890cfa7f6b7.png)   |

This is the email we send post-submission, so want to be consistent with that:

![Screenshot 2023-03-15 at 14 38 04](https://user-images.githubusercontent.com/56349171/225343451-fd121efc-d009-480f-9dc7-ba3eaf9549ad.png)

