### PR TITLE
Initial tweaks to the change registration confirmation page

### DIFF
--- a/app/views/registration-status/confirmation.html
+++ b/app/views/registration-status/confirmation.html
@@ -13,8 +13,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% set html %}
-      Your registration for {{ data ['chosenpq'] or "Leading teaching" }}
-      NPQ with {{ data['provider'] or "Ambition Institute" }} has been updated.
+      {% if (data['choosenpq'] == "Early headship coaching offer") %}
+      You’ve updated your registration for the Early headship coaching offer with {{ data['provider'] }}
+      {% else %}
+      You’ve updated your registration for the {{ data['choosenpq'] }} NPQ with {{ data['provider'] }}
+      {% endif %}
       {% endset %}
 
       {{ govukPanel({
@@ -26,9 +29,6 @@
         through {{ data['provider'] or "Ambition Institute"}}, if you have not done so already.</p>
       <p class="govuk-body">
         They’ll contact you by email to outline the next steps, including how to apply.
-      </p>
-      <p class="govuk-body">
-      There might be a delay in your provider contacting you while they prepare to open applications for October 2023.
       </p>
 
       <div class="govuk-inset-text">


### PR DESCRIPTION
Initial tweaks to the change registration confirmation page. Slight edit to the content including making it conditional so it works with both NPQs and the Early headship coaching offer. 

We may also want to outline the specific changes made on this page - will consider that in a separate PR. 

**Before** 

<img width="456" alt="Screenshot 2023-04-14 at 16 48 23" src="https://user-images.githubusercontent.com/56349171/232092466-d9de1ede-381c-4c6a-8002-41db66540d9e.png">


**After** 

<img width="518" alt="Screenshot 2023-04-14 at 16 49 35" src="https://user-images.githubusercontent.com/56349171/232092725-84273d48-7e02-404f-8105-e42212fdd7ac.png">

<img width="510" alt="Screenshot 2023-04-14 at 16 48 59" src="https://user-images.githubusercontent.com/56349171/232092599-098435e8-b5e6-4d69-8abc-bd10e05d5c0c.png">

