### PR TITLE
Edit start page

### DIFF
--- a/app/views/start-id.html
+++ b/app/views/start-id.html
@@ -14,8 +14,13 @@
         Register for a national professional qualification (NPQ)
       </h1>
       <p>
-        Use this service to register for an NPQ or the Early headship coaching offer.
+        Use this service to:
       </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>register for an NPQ or the Early headship coaching offer</li>
+        <li>check or change your registration details if you already registered</li>
+      </ul>
 
       <p>
         You also need to apply separately with your training provider. They’ll contact you once you’ve registered.
@@ -27,12 +32,15 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>which NPQ you want to do</li>
-        <li>who your provider is. If you have not chosen yet, <a href="/pdtl/professional-development-for-teachers-and-leaders">find out about NPQs and providers</a></li>
-        <li>If you work in early years or childcare, <a href="https://reports.ofsted.gov.uk/childcare">check if your workplace is registered with Ofsted</a> and get their unique reference number (URN) if they have one.</li>
+        <li>who your provider is</li>
       </ul>
 
+      <p>If you have not chosen yet, <a href="/pdtl/professional-development-for-teachers-and-leaders">find out about NPQs and providers</a>.</p>
+
+      <p>If you work in early years or childcare, <a href="https://reports.ofsted.gov.uk/childcare">check if your workplace is registered with Ofsted</a> and get their unique reference number (URN) if they have one.</p>
+
       <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-6 govuk-!-padding-top-6 govuk-!-padding-right-6 govuk-!-padding-bottom-1 govuk-!-padding-left-6" style="background-color:#f3f2f1;">
-        <p>To register for an NPQ you will need to sign in or create a DfE Identity account. We will take you through the process.</p>
+        <p>You’ll be asked to create or sign in to your DfE intentity account. We’ll show you how to do this.</p>
         <a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/id" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
   Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
@@ -41,9 +49,5 @@
         </a>
       </div>
 
-      <h2 class="govuk-heading-m">View your registration</h2>
-      <p>If you have already registered for an NPQ or the Early headship coaching offer you can <a href="https://get-an-identity-prototype.herokuapp.com/sign-in/email">sign in to your DfE Identity account</a> to view your registration and it's status.</p>
-    </div>
-  </div>
 
 {% endblock %}


### PR DESCRIPTION
Start pages normally just have one entry into the service via a button.

The next page (DfE identity account page) gives you the option to either create an account or sign in - so I think that page should be doing the heavy lifting to direct people to where they need to go. 

I've reverted back to one start point but made it clear from the content that the service can be used to check or change a previous registration. 

I've also edited the bullet points as the formatting doesn't quite work (the bullet points should make sense when read with the lead in sentence).


| **Before**  | **After**|
| ------------- |:-------------:|
| ![Screenshot 2023-06-02 at 10 28 21](https://github.com/DFE-Digital/npq-prototype/assets/56349171/65bed234-0aa9-471a-a089-a5b300804296)      | ![Screenshot 2023-06-02 at 10 28 46](https://github.com/DFE-Digital/npq-prototype/assets/56349171/b57a7ba7-0d35-4b94-b154-81edf1e1124a)     |


