### PR TITLE
1145 provider application status

### DIFF
--- a/app/views/registration-status/multiple-registrations.html
+++ b/app/views/registration-status/multiple-registrations.html
@@ -61,8 +61,7 @@
     ]
   }) }}
 
-
-<div class="govuk-rows" style="margin-top: 60px"></div>
+  <div class="govuk-rows" style="margin-top: 60px"></div>
 
   {{ govukTable({
     caption: "Headship NPQ registrations",
@@ -70,19 +69,16 @@
     firstCellIsHeader: false,
     head: [
       {
-        text: "Created at",
-        classes: "govuk-!-width-one-quarter"
+        text: "Created",
+        classes: "govuk-!-width-one-third"
       },
       {
-        text: "Status"
-      },
-      {
-        text: "Lead provider",
-        classes: "govuk-!-width-one-quarter"
+        text: "Provider",
+        classes: "govuk-!-width-one-third"
       },
       {
         text: "",
-        classes: "govuk-!-width-one-quarter"
+        classes: "govuk-!-width-one-third govuk-!-text-align-right"
       }
     ],
     rows: [
@@ -91,16 +87,11 @@
           text: "16 March 2023"
         },
         {
-          html:
-          '<strong class="govuk-tag govuk-tag--green">
-            accepted
-          </strong>'
-        },
-        {
           text: "Ambition Institute"
         },
         {
-          html: '<a href="npqh-registration">More details</a>'
+          html: '<a href="npqh-registration">More details</a>',
+          classes: "govuk-!-text-align-right"
         }
       ],
       [
@@ -108,16 +99,11 @@
           text: "16 March 2023"
         },
         {
-          html:
-          '<strong class="govuk-tag govuk-tag--yellow">
-            pending
-          </strong>'
-        },
-        {
           text: "Church of England"
         },
         {
-          html: '<a href="#">More details</a>'
+          html: '<a href="#">More details</a>',
+          classes: "govuk-!-text-align-right"
         }
       ],
       [
@@ -125,16 +111,11 @@
           text: "15 March 2023"
         },
         {
-          html:
-          '<strong class="govuk-tag govuk-tag--red">
-            rejected
-          </strong>'
-        },
-        {
           text: "Teach First"
         },
         {
-          html: '<a href="#">More details</a>'
+          html: '<a href="#">More details</a>',
+          classes: "govuk-!-text-align-right"
         }
       ]
     ]
@@ -142,84 +123,73 @@
 
   <div class="govuk-rows" style="margin-top: 60px"></div>
 
-    {{ govukTable({
-      caption: "Leading teaching NPQ registrations",
-      captionClasses: "govuk-table__caption--m",
-      firstCellIsHeader: false,
-      head: [
+  {{ govukTable({
+    caption: "Leading teaching NPQ registrations",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: false,
+    head: [
+      {
+        text: "Created",
+        classes: "govuk-!-width-one-third"
+      },
+      {
+        text: "Provider",
+        classes: "govuk-!-width-one-third"
+      },
+      {
+        text: "",
+        classes: "govuk-!-width-one-third"
+      }
+    ],
+    rows: [
+      [
         {
-          text: "Created at",
-          classes: "govuk-!-width-one-quarter"
+          text: "1 February 2022"
         },
         {
-          text: "Status",
-          classes: "govuk-!-width-one-quarter"
+          text: "UCL Institute of Education"
         },
         {
-          text: "Lead provider",
-          classes: "govuk-!-width-one-quarter"
-        },
-        {
-          text: "",
-          classes: "govuk-!-width-one-quarter"
+          html: '<a href="#">More details</a>',
+          classes: "govuk-!-text-align-right"
         }
-      ],
-      rows: [
-        [
-          {
-            text: "1 February 2022"
-          },
-          {
-            html:
-            '<strong class="govuk-tag govuk-tag--green">
-              passed
-            </strong>'
-          },
-          {
-            text: "UCL Institute of Education"
-          },
-          {
-            html: '<a href="#">More details</a>'
-          }
-        ]
       ]
+    ]
+  }) }}
+
+  <div class="govuk-rows" style="margin-top: 60px">
+    <h2 class="govuk-heading-l">Register for an NPQ</h2>
+    <p>Use this service to submit a new registration</p>
+
+    {{ govukButton({
+      text: "Register for an NPQ",
+      href: "/chosen"
     }) }}
+  </div>
 
-
- <div class="govuk-rows" style="margin-top: 60px">
-   <h2 class="govuk-heading-l">Register for an NPQ</h2>
-   <p>Use this service to submit a new registration</p>
-
-   {{ govukButton({
-     text: "Register for an NPQ",
-     href: "/chosen"
-   }) }}
- </div>
-
-
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            For prototype reference
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <h3 class="govuk-heading-s">Landing page showing different funding statuses </h3>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="/registration-status/registration-status">Eligible for Scholarship and Targeted support funding </a></li>
-            <li><a href="/registration-status/registration-status--scholarship-only">Eligible for Scholarship funding only </a></li>
-            <li><a href="/registration-status/registration-status--targeted-only">Eligible for Targeted support funding only </a></li>
-            <li><a href="/registration-status/registration-status--not-funded-england">Not eligible for funding – not in England </a></li>
-            <li><a href="/registration-status/registration-status--not-funded-ofsted">Not eligible for funding – not Ofsted </a></li>
-            <li><a href="/registration-status/registration-status--not-funded-setting">Not eligible for funding – not the right setting </a></li>
-            <li><a href="/registration-status/registration-status--scholarship-review">Not eligible for funding – in review </a></li>
-          </ul>
-          <h3 class="govuk-heading-s">Other landing page scenarios </h3>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="/registration-status/multiple-registrations">User with multiple registrations</a></li>
-            <li><a href="/registration-status/started">User with a registration for an NPQ that already started</a></li>
-          </ul>
-        </div>
-      </details>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        For prototype reference
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <h3 class="govuk-heading-s">Landing page showing different funding statuses </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="/registration-status/registration-status">Eligible for Scholarship and Targeted support funding </a></li>
+        <li><a href="/registration-status/registration-status--scholarship-only">Eligible for Scholarship funding only </a></li>
+        <li><a href="/registration-status/registration-status--targeted-only">Eligible for Targeted support funding only </a></li>
+        <li><a href="/registration-status/registration-status--not-funded-england">Not eligible for funding – not in England </a></li>
+        <li><a href="/registration-status/registration-status--not-funded-ofsted">Not eligible for funding – not Ofsted </a></li>
+        <li><a href="/registration-status/registration-status--not-funded-setting">Not eligible for funding – not the right setting </a></li>
+        <li><a href="/registration-status/registration-status--scholarship-review">Not eligible for funding – in review </a></li>
+      </ul>
+      <h3 class="govuk-heading-s">Other landing page scenarios </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="/registration-status/multiple-registrations">User with multiple registrations</a></li>
+        <li><a href="/registration-status/started">User with a registration for an NPQ that already started</a></li>
+      </ul>
+    </div>
+  </details>
 
 {% endblock %}

--- a/app/views/registration-status/multiple-registrations.html
+++ b/app/views/registration-status/multiple-registrations.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">Your registration</h1>
+  <h1 class="govuk-heading-xl">Your registrations</h1>
 
   <div class="govuk-rows" style="margin-top: 60px"></div>
 
@@ -69,7 +69,7 @@
     firstCellIsHeader: false,
     head: [
       {
-        text: "Created",
+        text: "Submitted",
         classes: "govuk-!-width-one-third"
       },
       {
@@ -129,7 +129,7 @@
     firstCellIsHeader: false,
     head: [
       {
-        text: "Created",
+        text: "Submitted",
         classes: "govuk-!-width-one-third"
       },
       {

--- a/app/views/registration-status/npqh-registration.html
+++ b/app/views/registration-status/npqh-registration.html
@@ -23,14 +23,6 @@
         card: {
           title: {
             text: "Course details"
-          },
-          actions: {
-            items: [
-              {
-                href: "change-course/choose-npq",
-                text: "Change course"
-              }
-            ]
           }
         },
         rows: [
@@ -40,6 +32,30 @@
             },
             value: {
               html: "Headship NPQ"
+            },
+            actions: {
+              items: [
+                {
+                  href: "change-course/choose-npq",
+                  text: "Change course"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Provider"
+            },
+            value: {
+              html: "Ambition Institute"
+            },
+            actions: {
+              items: [
+                {
+                  href: "change-provider/choose-provider",
+                  text: "Change provider"
+                }
+              ]
             }
           },
           {
@@ -50,7 +66,8 @@
               html:
                 '<strong class="govuk-tag govuk-tag--blue">
                   submitted
-                </strong>'
+                </strong>
+                <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
             }
           },
           {
@@ -79,46 +96,5 @@
           }
         ]
       }) }}
-
-      {{ govukSummaryList({
-        card: {
-          title: {
-            text: "Provider details"
-          },
-          actions: {
-            items: [
-              {
-                href: "/registration-status/change-provider/choose-provider",
-                text: "Change provider"
-              }
-            ]
-          }
-        },
-        rows: [
-          {
-            key: {
-              text: "Provider"
-            },
-            value: {
-              html: "Ambition Institute"
-            }
-          },
-          {
-            key: {
-              text: "Provider application"
-            },
-            value: {
-              html:
-                '<strong class="govuk-tag govuk-tag--green">
-                  accepted
-                </strong>'
-            }
-          }
-        ]
-      }) }}
-
-
-
-
 
 {% endblock %}

--- a/app/views/registration-status/registration-status--not-funded-england.html
+++ b/app/views/registration-status/registration-status--not-funded-england.html
@@ -76,15 +76,7 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
-      }
+      }      
     },
     rows: [
       {
@@ -93,6 +85,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -103,7 +119,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -112,43 +129,6 @@
         },
         value: {
           html: scholarshipfundingHtml
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status--not-funded-ofsted.html
+++ b/app/views/registration-status/registration-status--not-funded-ofsted.html
@@ -76,14 +76,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -93,6 +85,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -103,7 +119,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -112,43 +129,6 @@
         },
         value: {
           html: scholarshipfundingHtml
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status--not-funded-setting.html
+++ b/app/views/registration-status/registration-status--not-funded-setting.html
@@ -76,14 +76,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -93,6 +85,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -103,7 +119,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -112,43 +129,6 @@
         },
         value: {
           html: scholarshipfundingHtml 
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status--scholarship-only.html
+++ b/app/views/registration-status/registration-status--scholarship-only.html
@@ -68,14 +68,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -85,6 +77,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -95,7 +111,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -108,43 +125,6 @@
               Eligible
             </strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">This means that you will not have to pay for the course fees.</p>'
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status--scholarship-review.html
+++ b/app/views/registration-status/registration-status--scholarship-review.html
@@ -75,14 +75,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -92,6 +84,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -102,7 +118,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -111,43 +128,6 @@
         },
         value: {
           html: scholarshipfundingHtml
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status--targeted-only.html
+++ b/app/views/registration-status/registration-status--targeted-only.html
@@ -68,14 +68,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -85,6 +77,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -95,7 +111,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -122,43 +139,6 @@
               Eligible
             </strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your workplace will receive £600 to support you to do this NPQ.</p>'
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/registration-status.html
+++ b/app/views/registration-status/registration-status.html
@@ -68,14 +68,6 @@
     card: {
       title: {
         text: "Course details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-course/choose-npq",
-            text: "Change course"
-          }
-        ]
       }
     },
     rows: [
@@ -85,6 +77,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -95,7 +111,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -120,43 +137,6 @@
               Eligible
             </strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your workplace will receive £200 to support you to do this NPQ.</p>'
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      },
-      actions: {
-        items: [
-          {
-            href: "change-provider/choose-provider",
-            text: "Change provider"
-          }
-        ]
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--yellow">
-              pending
-            </strong>'
         }
       }
     ]

--- a/app/views/registration-status/started.html
+++ b/app/views/registration-status/started.html
@@ -78,6 +78,30 @@
         },
         value: {
           html: "Leading teaching NPQ"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-course/choose-npq",
+              text: "Change course"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Provider"
+        },
+        value: {
+          html: "Ambition Institute"
+        },
+        actions: {
+          items: [
+            {
+              href: "change-provider/choose-provider",
+              text: "Change provider"
+            }
+          ]
         }
       },
       {
@@ -88,7 +112,8 @@
           html:
             '<strong class="govuk-tag govuk-tag--blue">
               submitted
-            </strong>'
+            </strong>
+            <p class="govuk-!-margin-top-2">You also need to apply separately with your training provider, if you have not done so already.</p>'
         }
       },
       {
@@ -113,35 +138,6 @@
               Eligible
             </strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your workplace will receive £200 to support you to do this NPQ.</p>'
-        }
-      }
-    ]
-  }) }}
-
-  {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Provider details"
-      }
-    },
-    rows: [
-      {
-        key: {
-          text: "Provider"
-        },
-        value: {
-          html: "Ambition Institute"
-        }
-      },
-      {
-        key: {
-          text: "Provider application"
-        },
-        value: {
-          html:
-            '<strong class="govuk-tag govuk-tag--turquoise">
-              started
-            </strong>'
         }
       }
     ]


### PR DESCRIPTION
**On registration status pages:**
- Removing Provider details table
- Adding Provider to the Course details table 
- Adding info beneath Registration status reminding users to apply with provider 
- Moving 'Change course' and 'Change provider' links to the associated row

| **Before**  | **After**|
| ------------- |:-------------:|
|![provider-details--before](https://github.com/DFE-Digital/npq-prototype/assets/53426640/768471cd-6f29-477d-ab4e-324ac5054c29)      | ![provider-details--after](https://github.com/DFE-Digital/npq-prototype/assets/53426640/e4ca894e-961c-4ddf-a29a-f43ab8e561e2)     |

**On multiple registrations page:**
- Removing status 
- Changing 'created at' column name to 'Submitted'
- Changing 'Lead provider' column name to 'Provider'
- Pluralising page title 'Your registrations'
- Right aligning 'more details' links 

| **Before**  | **After**|
| ------------- |:-------------:|
|![multiple-registrations--before](https://github.com/DFE-Digital/npq-prototype/assets/53426640/892a3b3e-a993-4124-b655-fed658a7e4f8)      | ![multiple-registrations--after](https://github.com/DFE-Digital/npq-prototype/assets/53426640/5dbcad3d-2d6a-483a-8932-dcb232106611)     |




