### PR TITLE
Capping changes to funding content

### DIFF
--- a/app/views/funding/edge-case.html
+++ b/app/views/funding/edge-case.html
@@ -22,9 +22,9 @@
       </h1>
       <p>Your registration will be reviewed by the Department for Education (DfE) to check if you’re eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ starting before November 2024.</p>
 
-      <p>If you are eligible, you would not have to pay for the course fees.</p>
+      <p>If you are eligible, and the provider confirms that you have a funded space, you will not have to pay for the course fees.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">Your provider will be notified of your funding eligibility so you should check the outcome with them.</p>
+    
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/funding/funding-eligible-maths.html
+++ b/app/views/funding/funding-eligible-maths.html
@@ -20,9 +20,9 @@
       <h1 class="govuk-heading-xl">
         Funding 
       </h1>
-      <p>If your provider accepts your application, you’ll be eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ starting before November 2024.</p>
+      <p>You're eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ starting before November 2024.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">This means that you will not have to pay for the course fees.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">This means that if the provider accepts your application and confirms that you have a funded space, you will not have to pay for the course fees.</p>
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/funding/funding-eligible.html
+++ b/app/views/funding/funding-eligible.html
@@ -22,7 +22,7 @@
       </h1>
       <p>You're eligible for scholarship funding for the {{ data['choosenpq'] }} NPQ starting before November 2024.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">This means that you will not have to pay for the course fees.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">This means that if the provider accepts your application and confirms that you have a funded space, you will not have to pay for the course fees.</p>
 
       {{ govukButton({
         text: "Continue",

--- a/app/views/registration-status/registration-status--scholarship-only.html
+++ b/app/views/registration-status/registration-status--scholarship-only.html
@@ -17,7 +17,7 @@
 
 {% set coursedateHTML %}
   <p>Before November 2024</p>
-  <p>If your provider doesn't confirm you've started the course before November 2024, your registration will expire. You can register again later, but your funding may change.</p>
+  <p>If your provider does not confirm you've started the course before November 2024, your registration will expire. You can register again later, but your funding may change.</p>
 {% endset %}
             
 {% block content %}


### PR DESCRIPTION
Changed messaging to be clear that providers need to confirm if scholarship will be given,