### PR TITLE
1710 registration updates after UR

### DIFF
--- a/app/assets/sass/components/_utilities.scss
+++ b/app/assets/sass/components/_utilities.scss
@@ -9,3 +9,7 @@
 .govuk-colour-white {
   color: #ffffff;
 }
+
+.display-none {
+  display: none;
+}

--- a/app/routes/id-routes.js
+++ b/app/routes/id-routes.js
@@ -76,10 +76,12 @@ module.exports = router => {
 
     let closedState = req.session.data.closedState
   
-    if (closedState === '') {
-        res.redirect('/course-start')
-      } else {
+    if (closedState === 'full') {
+        res.redirect('/start-id')
+      } else if (closedState === 'partial'){
         res.redirect('/registrations-closed')
+      } else {
+      res.redirect('/course-start')
     }
   })
 

--- a/app/views/apply-later.html
+++ b/app/views/apply-later.html
@@ -20,9 +20,7 @@
 
     <p>Registrations are currently only open for courses starting before November 2024.</p>
 
-    <p class="govuk-body">Registrations for courses starting later in the year usually open in the spring.</p>
-
-    <p class="govuk-body govuk-!-margin-bottom-7">You'll receive an email when registrations open.</p>
+    <p class="govuk-body">Registrations for courses starting later in the year usually open in the spring. <a href="/eoi-register-later/eoi-question"><strong>Request email updates to tell you when registration opens</a></strong>. You can also tell us about your interest in the special educational needs coordinator (SENCO) NPQ course.</p>
 
   </div>
 </div>

--- a/app/views/course-start.html
+++ b/app/views/course-start.html
@@ -22,7 +22,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">Course start</h1>
-    <p>NPQ start dates are usually every February and October.</p>
+    <p>NPQ start dates are usually every April and October.</p>
     <p>Early headship coaching offer start dates vary by provider and are throughout the year.</p>
     <p class="govuk-body govuk-!-margin-bottom-8">Registrations are currently open for courses starting before November 2024.</p>
 

--- a/app/views/eoi-register-later/eoi-question.html
+++ b/app/views/eoi-register-later/eoi-question.html
@@ -1,0 +1,56 @@
+{% extends "layout.html" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set signedIn = 'true' %}
+
+{% block pageTitle %}
+  Request email updates about registration opening
+{% endblock %}
+
+{% block beforeContent %}
+  {%- if not data['signedIn'] -%}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+  {%- endif -%}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Request email updates about registration opening for courses starting after November 2024 </h1>
+    
+    <form class="form" action="/eoi-register-later/eoi-success" method="post">
+      {{ govukRadios({
+        name: "eoi-senco",
+        fieldset: {
+          legend: {
+            text: "Do you want to register for the special educational needs co-ordinator (SENCO) NPQ when registration opens?",
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No, I want to do a different NPQ"
+          }
+        ]
+      }) }}
+
+      <p>By requesting email updates, you agree to our <a href="https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#NPQ">privacy notice</a>.</p>
+
+      {{ govukButton({
+        text: "Request email updates"
+      }) }}
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/eoi-register-later/eoi-success.html
+++ b/app/views/eoi-register-later/eoi-success.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+
+{% set signedIn = 'true' %}
+
+{% block pageTitle %}
+  Your email alert has been set up
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: "Your email request has been set up"
+      }) }}
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>We'll send email updates to <strong>{{ data['email'] or 'example@email.com' }}</strong> about registration opening for courses starting after November 2024. This is usually in the new year.</p>
+      {% if data['numberOfRegistrations'] != "0" %} 
+        <p><a href="/registration-status">View your existing registrations</a>.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/registration-status/registration-status--not-funded-england.html
+++ b/app/views/registration-status/registration-status--not-funded-england.html
@@ -38,6 +38,10 @@
   {% endif %}
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% block content %}
   <span class="govuk-caption-m">Submitted	10 April 2021</span>
   <h1 class="govuk-heading-xl">
@@ -110,6 +114,25 @@
         },
         value: {
           html: courseFundingHtml
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status--not-funded-ofsted.html
+++ b/app/views/registration-status/registration-status--not-funded-ofsted.html
@@ -38,6 +38,10 @@
   {% endif %}
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% block content %}
   <span class="govuk-caption-m">Submitted	17 March 2021</span>
   <h1 class="govuk-heading-xl">
@@ -110,6 +114,25 @@
         },
         value: {
           html: courseFundingHtml
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status--not-funded-setting.html
+++ b/app/views/registration-status/registration-status--not-funded-setting.html
@@ -30,6 +30,10 @@
   {% endif %}
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% block content %}
   <span class="govuk-caption-m">Submitted	2 July 2024</span>
   <h1 class="govuk-heading-xl">
@@ -121,6 +125,25 @@
         },
         value: {
           html: courseFundingHtml
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status--scholarship-only.html
+++ b/app/views/registration-status/registration-status--scholarship-only.html
@@ -20,6 +20,10 @@
   <p>If your provider does not confirm you've started the course before November 2024, your registration will expire. You can register again later, but your funding may change.</p>
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% set fundingHTML %}
   <strong class="govuk-tag govuk-tag--green">
     Eligible
@@ -124,6 +128,25 @@
         },
         value: {
           html: fundingHTML
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status--scholarship-review.html
+++ b/app/views/registration-status/registration-status--scholarship-review.html
@@ -31,6 +31,10 @@
   <p>If your provider does not confirm you've started the course before November 2024, your registration will expire. You can register again later, but your funding may change.</p>
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% set scholarshipfundingHtml %}
   <p>Contact LLSE to check if you're eligible for scholarship funding and that they can offer you a scholarship funded space, if you have not done so already.</p>
 
@@ -135,6 +139,25 @@
         },
         value: {
           html: scholarshipfundingHtml
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status--targeted-support.html
+++ b/app/views/registration-status/registration-status--targeted-support.html
@@ -16,6 +16,10 @@
   <p>If your provider does not confirm you've started the course before April 2024, your registration will expire. You can register again later, but your funding may change.</p>
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back to your registrations",
@@ -123,6 +127,25 @@
               Eligible
             </strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your workplace will receive £200 to support you to do this NPQ.</p>'
+        }
+      }
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
         }
       }
     ]

--- a/app/views/registration-status/registration-status.html
+++ b/app/views/registration-status/registration-status.html
@@ -40,6 +40,10 @@
   <p>If your provider does not confirm you've started the course before November 2024, your registration will expire. You can register again later, but your funding may change.</p>
 {% endset %}
 
+{% set personaldetailsHTML %}
+  <p><a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.</p>
+{% endset %}
+
 {% set scholarshipFundingHTML %}
   <!-- Not in England -->
   {% if data['wheredoyouwork'] == "No" %}
@@ -183,10 +187,6 @@
     {% endif %}
   </h1>
 
-  {{ govukInsetText({
-    html: '<a href="https://get-an-identity-prototype.herokuapp.com/user-research/npq/account">Visit your DfE Identity account</a> to check or change your personal details.'
-  }) }}
-
   {{ govukSummaryList({
     card: {
       title: {
@@ -272,6 +272,25 @@
           text: data['payment'] or "I'm paying"
         }
       } if (data['referrer'] != "inreview") and (data['referrer'] != "funded")
+    ]
+  }) }}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        text: "Personal details"
+      }
+    },
+    rows: [
+      {
+        key: {
+          classes: "display-none"
+        },
+        value: {
+          html: personaldetailsHTML,
+          classes: "govuk-!-width-full-width"
+        }
+      }
     ]
   }) }}
 


### PR DESCRIPTION
@Dom-Collins could you have a look over the changes I've made here and update any content? 

Using the closed EoI flow as a base (but that flow won't actually change). This is to update the EoI route when registrations are open. Currently we auto-opt people in to receive email updates if they say 'no' to starting before November. 

Also in this PR I've updated the personal details link on the registration details pages to match how it is on live (no content changed). 

| Before | After |
|--------|--------|
| Changed dates ![Screenshot 2024-04-22 at 14 42 00](https://github.com/DFE-Digital/npq-prototype/assets/53426640/f4939d89-199d-43de-8eb2-9f0165dd379a) | ![Screenshot 2024-04-22 at 14 41 17](https://github.com/DFE-Digital/npq-prototype/assets/53426640/1e256fa2-e3a4-4347-8a75-a63356d84666) |
| Add link to request email updates, rather than auto opt-in ![Screenshot 2024-04-22 at 14 42 08](https://github.com/DFE-Digital/npq-prototype/assets/53426640/6beea3b7-e593-4b0e-9771-7ac9befba94c) | ![Screenshot 2024-04-22 at 14 41 12](https://github.com/DFE-Digital/npq-prototype/assets/53426640/d4e00f72-91bc-4bab-a0c2-11449df68d61) | 
| Updated content as this is used when service is open ![Screenshot 2024-04-22 at 14 41 43](https://github.com/DFE-Digital/npq-prototype/assets/53426640/8bb3f706-1a37-4e6f-ba9e-2f0e6569da6b) | ![Screenshot 2024-04-22 at 14 41 08](https://github.com/DFE-Digital/npq-prototype/assets/53426640/83b11f4e-b51d-4d04-8c52-c7d903d8fedf) |
| Updated content as this is used when service is open ![Screenshot 2024-04-22 at 14 41 47](https://github.com/DFE-Digital/npq-prototype/assets/53426640/fcf25789-56cd-41fc-976c-6deaad7a2d89) | ![Screenshot 2024-04-22 at 14 41 03](https://github.com/DFE-Digital/npq-prototype/assets/53426640/a1e0daab-8e89-425f-b3a8-14b53ff2db38) |
