### PR TITLE
Change order of 'return to teaching' and 'work in England' questions. 

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -27,11 +27,21 @@ router.post('/chosen', function(req, res){
   }
 })
 
-router.post('/route-return-to-teaching', function(req, res){
+router.post('/route-where-do-you-work', function(req, res){
   var choosenpqprovidert = req.session.data['choosenpqprovider']
 
   if (choosenpqprovidert == 'no') {
     res.redirect('/choose-an-npq-and-provider')
+  } else {
+    res.redirect('/where-do-you-work')
+  }
+})
+
+router.post('/route-return-to-teaching', function(req, res){
+  var locationt = req.session.data['wheredoyouwork']
+
+  if (locationt == 'No') {
+    res.redirect('/what-setting')
   } else {
     res.redirect('/return-to-teaching')
   }

--- a/app/views/chosen.html
+++ b/app/views/chosen.html
@@ -20,7 +20,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form class="form" action="route-return-to-teaching" method="post">
+    <form class="form" action="route-where-do-you-work" method="post">
       {{ govukRadios({
         name: "choosenpqprovider",
         fieldset: {

--- a/app/views/includes/answers/ey-funded.html
+++ b/app/views/includes/answers/ey-funded.html
@@ -22,20 +22,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -50,6 +36,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/ey-no-ofsted.html
+++ b/app/views/includes/answers/ey-no-ofsted.html
@@ -22,20 +22,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -50,6 +36,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/ey-state-nursery.html
+++ b/app/views/includes/answers/ey-state-nursery.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/not-eng.html
+++ b/app/views/includes/answers/not-eng.html
@@ -22,20 +22,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -50,6 +36,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           {% if (data['teachadvisory'] == "No") %}
             <div class="govuk-summary-list__row">

--- a/app/views/includes/answers/other-hospital-young-offenders.html
+++ b/app/views/includes/answers/other-hospital-young-offenders.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/other-itt.html
+++ b/app/views/includes/answers/other-itt.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/other-local-authority.html
+++ b/app/views/includes/answers/other-local-authority.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/other.html
+++ b/app/views/includes/answers/other.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/private-school.html
+++ b/app/views/includes/answers/private-school.html
@@ -22,20 +22,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -50,6 +36,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/returner-teacher.html
+++ b/app/views/includes/answers/returner-teacher.html
@@ -19,20 +19,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -47,6 +33,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/answers/school-funded.html
+++ b/app/views/includes/answers/school-funded.html
@@ -22,20 +22,6 @@
               </a>
             </dd>
           </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Referred by return to teaching adviser
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['teachadvisory']}}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="return-to-teaching">
-                Change<span class="govuk-visually-hidden"> referral</span>
-              </a>
-            </dd>
-          </div>
           
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -50,6 +36,22 @@
               </a>
             </dd>
           </div>
+
+          {% if (data['wheredoyouwork'] == "Yes") %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Referred by return to teaching adviser
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['teachadvisory']}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="return-to-teaching">
+                  Change<span class="govuk-visually-hidden"> referral</span>
+                </a>
+              </dd>
+            </div>
+          {% endif %}
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/app/views/includes/registration-status/work-details/ey-funded.html
+++ b/app/views/includes/registration-status/work-details/ey-funded.html
@@ -47,17 +47,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
-  rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },  
+  rows: [ 
     {
       key: {
         text: "Workplace in England"
@@ -66,6 +58,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/ey-no-ofsted.html
+++ b/app/views/includes/registration-status/work-details/ey-no-ofsted.html
@@ -43,17 +43,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
-  rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },  
+  rows: [  
     {
       key: {
         text: "Workplace in England"
@@ -62,6 +54,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/ey-state-nursery.html
+++ b/app/views/includes/registration-status/work-details/ey-state-nursery.html
@@ -47,17 +47,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -66,6 +58,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/not-eng.html
+++ b/app/views/includes/registration-status/work-details/not-eng.html
@@ -39,17 +39,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -58,6 +50,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/other-hospital-yoi.html
+++ b/app/views/includes/registration-status/work-details/other-hospital-yoi.html
@@ -51,17 +51,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -70,6 +62,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/other-itt.html
+++ b/app/views/includes/registration-status/work-details/other-itt.html
@@ -47,17 +47,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -66,6 +58,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/other-local-authority.html
+++ b/app/views/includes/registration-status/work-details/other-local-authority.html
@@ -51,17 +51,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -70,6 +62,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/other.html
+++ b/app/views/includes/registration-status/work-details/other.html
@@ -51,17 +51,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -70,6 +62,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/private-school.html
+++ b/app/views/includes/registration-status/work-details/private-school.html
@@ -43,17 +43,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -62,6 +54,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/includes/registration-status/work-details/return-teaching-adviser.html
+++ b/app/views/includes/registration-status/work-details/return-teaching-adviser.html
@@ -39,17 +39,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        html: returnTeacherHtml
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -58,6 +50,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Completed one year of the primary maths Teaching for Mastery programme"

--- a/app/views/includes/registration-status/work-details/school-funded.html
+++ b/app/views/includes/registration-status/work-details/school-funded.html
@@ -43,17 +43,9 @@
           classes: "govuk-!-font-weight-regular"
         }
       ]
-    } if courseOutcome != "Started"
+    } if data['courseOutcome'] != "Started"
   },
   rows: [
-    {
-      key: {
-        text: "Referred by return to teaching adviser"
-      },
-      value: {
-        text: data['teachadvisory'] or 'No'
-      }
-    },
     {
       key: {
         text: "Workplace in England"
@@ -62,6 +54,14 @@
         html: englandHtml
       }
     },
+    {
+      key: {
+        text: "Referred by return to teaching adviser"
+      },
+      value: {
+        text: data['teachadvisory'] or 'No'
+      }
+    } if data['wheredoyouwork'] == "Yes",
     {
       key: {
         text: "Work setting"

--- a/app/views/other/employment.html
+++ b/app/views/other/employment.html
@@ -43,7 +43,10 @@
           },
           {
             value: "As a teacher employed by a local authority to teach in more than one school",
-            text: "As a teacher employed by a local authority to teach in more than one school"
+            text: "As a teacher employed by a local authority to teach in more than one school",
+            hint: {
+              text: "This could be as a supply teacher or peripatetic teacher."
+            }
           },
           {
             value: "As a lead mentor for an accredited initial teacher training (ITT) provider",

--- a/app/views/return-to-teaching.html
+++ b/app/views/return-to-teaching.html
@@ -32,7 +32,7 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <form class="form" action="where-do-you-work" method="post">
+    <form class="form" action="route-what-setting" method="post">
       {{ govukRadios({
         name: "teachadvisory",
         id: "teachadvisory",

--- a/app/views/where-do-you-work.html
+++ b/app/views/where-do-you-work.html
@@ -15,7 +15,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form class="form" action="route-what-setting" method="post">
+      <form class="form" action="route-return-to-teaching" method="post">
         {{ govukRadios({
           id: "wheredoyouwork",
           name: "wheredoyouwork",


### PR DESCRIPTION
Change order of 'return to teaching' and 'work in England' questions. 
Reflect that on check answers and registration details pages. 
Add hint text to Other employment radio button.