### PR TITLE
Content added for DP list for 2025 to 2026 cohorts

### DIFF
--- a/app/views/admin-v3/ambition-24.html
+++ b/app/views/admin-v3/ambition-24.html
@@ -14,24 +14,24 @@
 
           <h4 class="moj-side-navigation__title">Ambition Institute</h4>
 
-          <li class="moj-side-navigation__item">
-            <a href="ambition.html" aria-current="location">Cohort 2025/26</a>
-          </li>
-  
           <li class="moj-side-navigation__item moj-side-navigation__item--active">
-            <a href="ambition-24.html">Cohort 2024/25</a>
+            <a href="ambition.html">Cohort 2025 to 2026</a>
           </li>
   
           <li class="moj-side-navigation__item">
-            <a href=" ">Cohort 2023/24</a>
+            <a href="ambition-24.html">Cohort 2024 to 2025</a>
+          </li>
+  
+          <li class="moj-side-navigation__item">
+            <a href=" ">Cohort 2023 to 2024</a>
           </li>
 
           <li class="moj-side-navigation__item">
-            <a href=" ">Cohort 2022/23</a>
+            <a href=" ">Cohort 2022 to 2023</a>
           </li>
 
           <li class="moj-side-navigation__item">
-            <a href="   ">Cohort 2021/22</a>
+            <a href="   ">Cohort 2021 to 2022</a>
           </li>
 
          
@@ -49,15 +49,17 @@
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1">Ambition Institute</h1>
       <br>
+             <h2 class="govuk-heading-m">Cohort 2024 to 2025</h2>
 
-      <p>
-        Here is a list of delivery partners who have collaborated with Ambition Institute<br> to deliver NPQs for this cohort 2024/25.      
-      </p>
+      <p> List of delivery partners linked to Ambition Institute for this cohort.</p>
+
+
+
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Delivery partner
+            Delivery partners
           </dt>
           <dd class="govuk-summary-list__value">
              
@@ -65,32 +67,32 @@
         </div>
          <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Flying High Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           LEAD Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Potentia Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Redhill Teaching Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Saffron Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Aldridge Education  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/admin-v3/ambition.html
+++ b/app/views/admin-v3/ambition.html
@@ -15,23 +15,23 @@
           <h4 class="moj-side-navigation__title">Ambition Institute</h4>
 
           <li class="moj-side-navigation__item moj-side-navigation__item--active">
-            <a href="" aria-current="location">Cohort 2025/26</a>
+            <a href="ambition.html">Cohort 2025 to 2026</a>
           </li>
   
           <li class="moj-side-navigation__item">
-            <a href="ambition-24.html">Cohort 2024/25</a>
+            <a href="ambition-24.html">Cohort 2024 to 2025</a>
           </li>
   
           <li class="moj-side-navigation__item">
-            <a href=" ">Cohort 2023/24</a>
+            <a href=" ">Cohort 2023 to 2024</a>
           </li>
 
           <li class="moj-side-navigation__item">
-            <a href=" ">Cohort 2022/23</a>
+            <a href=" ">Cohort 2022 to 2023</a>
           </li>
 
           <li class="moj-side-navigation__item">
-            <a href="   ">Cohort 2021/22</a>
+            <a href="   ">Cohort 2021 to 2022</a>
           </li>
 
          
@@ -49,15 +49,17 @@
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1">Ambition Institute</h1>
       <br>
+             <h2 class="govuk-heading-m">Cohort 2025 to 2026</h2>
 
-      <p>
-        Here is a list of delivery partners who have collaborated with Ambition Institute<br> to deliver NPQs for this cohort 2025/26.      
-      </p>
+      <p> List of delivery partners linked to Ambition Institute for this cohort.</p>
+
+
+
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Delivery partner
+            Delivery partners
           </dt>
           <dd class="govuk-summary-list__value">
              
@@ -65,32 +67,32 @@
         </div>
          <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Flying High Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           LEAD Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Potentia Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Redhill Teaching Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Saffron Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Aldridge Education  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/admin-v3/bpn.html
+++ b/app/views/admin-v3/bpn.html
@@ -39,7 +39,7 @@
          
           
 
-        </ul>
+         </ul>
       </nav>
     </div>
 
@@ -49,15 +49,17 @@
 
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1">Best Practice Network</h1>
       <br>
+             <h2 class="govuk-heading-m">Cohort 2025 to 2026</h2>
 
-      <p>
-        Here is a list of delivery partners who have collaborated with Best Practice Network<br> to deliver NPQs for this cohort 2025/26.      
-      </p>
+      <p> List of delivery partners linked to Best Practice Network for this cohort.</p>
+
+
+
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Delivery partner
+            Delivery partners
           </dt>
           <dd class="govuk-summary-list__value">
              
@@ -65,32 +67,32 @@
         </div>
          <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Flying High Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           LEAD Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Potentia Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Redhill Teaching Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Saffron Teaching School Hub  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-           Delivery partner name  
+           Aldridge Education  
           </dd>   
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/admin-v3/course-providers.html
+++ b/app/views/admin-v3/course-providers.html
@@ -51,7 +51,9 @@
       <br>
 
       <p>
-        Here is a list of all providers that currently deliver NPQ courses. <br> Select a course provider to review all the delivery partners that <br> help them deliver NPQs. 
+        Here is a list of all course providers that offer national professional qualification (NPQ) courses. <br>
+        
+        <br> Select a course provider to reveal which delivery partners they work with to deliver NPQs.
       </p>
 
     </div>


### PR DESCRIPTION
Added content to show lists of delivery partners that are attached to course providers for each cohort. See images for changes:

![image](https://github.com/user-attachments/assets/41c74025-8c92-49d6-bdbb-e4b8a6c5b471)
![image](https://github.com/user-attachments/assets/63d2013f-2014-4cf1-ab75-264d689b2795)
![image](https://github.com/user-attachments/assets/788bf74a-02b6-4c9e-bf8e-9ef2c2d01b97)
